### PR TITLE
Add `withDefault` helper.

### DIFF
--- a/handlebars-helpers.js
+++ b/handlebars-helpers.js
@@ -98,7 +98,7 @@
         return moment(date).format(format);
     };
 
-    // Join an array of strings, with an optional `pluck` argument 
+    // Join an array of strings, with an optional `pluck` argument
     // if the passed array contains objects, rather than simple items.
     // Default sepeator is ','
     //
@@ -146,6 +146,21 @@
             .trim();
     };
 
+
+    /* If the given `string` variable is falsy, returns `defaultString`. Otherwise,
+    * use the `string` value. If `defaultString` is not given, it will defaults
+    * to "(empty)".
+    */
+    var withDefault = function (string, defaultString) {
+
+      if (!_.isString(defaultString)) {
+        defaultString = new Handlebars.SafeString('<em>(empty)</em>')
+      }
+
+      return string || defaultString
+    };
+
+
     var localHelpers = {
         commonName: commonName,
         dateRange: dateRange,
@@ -157,7 +172,8 @@
         sentenceCase: sentenceCase,
         simpleTrans: simpleTrans,
         trans: trans,
-        slugify: slugify
+        slugify: slugify,
+        withDefault: withDefault
     };
 
     // Register all helpers.

--- a/test/test.js
+++ b/test/test.js
@@ -60,4 +60,14 @@ describe("Handlebars Helpers", function() {
         assert.equal(helpers.slugify("funk !#@!#"), "funk-");
         assert.equal(helpers.slugify("#@!*&^%#123"), "123");
     });
+
+    it("should provide default string if variable is falsy", function() {
+        assert.equal(helpers.withDefault("A string", "default"), "A string");
+        assert.equal(helpers.withDefault("", "default"), "default");
+        assert.equal(helpers.withDefault(null, "default"), "default");
+
+        assert.equal(helpers.withDefault("A string"), "A string");
+        assert.equal(helpers.withDefault(""), "<em>(empty)</em>");
+        assert.equal(helpers.withDefault(null), "<em>(empty)</em>");
+    });
 });


### PR DESCRIPTION
It adds the ability to provide a default string to display in case the given
variable is falsy.

/cc @bartek 
