### PR TITLE
Add `linebreaks` helper to handle paragraphs in plain text

### DIFF
--- a/handlebars-helpers.js
+++ b/handlebars-helpers.js
@@ -161,6 +161,22 @@
     };
 
 
+    /* Replaces line breaks in plain text with appropriate HTML; a single
+     * newline becomes an HTML line break (<br />) and a new line followed by a
+     * blank line becomes a paragraph break (</p>).
+     *
+     * Similar to the `linebreaks` filter in Django templates.
+     */
+
+    var linebreaks = function(string) {
+        var paragraphs = string.split(/(?:\r?\n){2,}/).filter(Boolean);
+        var wrappedParagraphs = paragraphs.map(function (p) {
+            return '<p>' + p.replace(/\r?\n/, '<br />') + '</p>';
+        });
+        return new Handlebars.SafeString(wrappedParagraphs.join('\n\n'));
+    };
+
+
     var localHelpers = {
         commonName: commonName,
         dateRange: dateRange,
@@ -173,7 +189,8 @@
         simpleTrans: simpleTrans,
         trans: trans,
         slugify: slugify,
-        withDefault: withDefault
+        withDefault: withDefault,
+        linebreaks: linebreaks
     };
 
     // Register all helpers.

--- a/test/test.js
+++ b/test/test.js
@@ -70,4 +70,24 @@ describe("Handlebars Helpers", function() {
         assert.equal(helpers.withDefault(""), "<em>(empty)</em>");
         assert.equal(helpers.withDefault(null), "<em>(empty)</em>");
     });
+
+    it("should wrap paragraphs in HTML 'p' tags, and replace single newlines with 'br' tags", function() {
+        assert.equal(helpers.linebreaks("A string"), "<p>A string</p>");
+        assert.equal(helpers.linebreaks("A\nstring"), "<p>A<br />string</p>");
+        assert.equal(helpers.linebreaks("A\n\nstring"), "<p>A</p>\n\n<p>string</p>");
+        assert.equal(helpers.linebreaks("A\n\n\nstring"), "<p>A</p>\n\n<p>string</p>");
+        assert.equal(helpers.linebreaks("A\n\nbig\nstring"), "<p>A</p>\n\n<p>big<br />string</p>");
+        assert.equal(helpers.linebreaks("A\n\nstring\n\n"), "<p>A</p>\n\n<p>string</p>");
+        assert.equal(helpers.linebreaks("A string\n"), "<p>A string<br /></p>");
+
+        assert.equal(helpers.linebreaks("A\r\nstring"), "<p>A<br />string</p>");
+        assert.equal(helpers.linebreaks("A\r\n\r\nstring"), "<p>A</p>\n\n<p>string</p>");
+        assert.equal(helpers.linebreaks("A\r\n\r\n\r\nstring"), "<p>A</p>\n\n<p>string</p>");
+        assert.equal(helpers.linebreaks("A\r\n\r\nbig\r\nstring"), "<p>A</p>\n\n<p>big<br />string</p>");
+        assert.equal(helpers.linebreaks("A\r\n\r\nstring\r\n\r\n"), "<p>A</p>\n\n<p>string</p>");
+        assert.equal(helpers.linebreaks("A string\r\n"), "<p>A string<br /></p>");
+
+        assert.equal(helpers.linebreaks("A\r\n\nstring"), "<p>A</p>\n\n<p>string</p>");
+        assert.equal(helpers.linebreaks("A\n\r\nstring"), "<p>A</p>\n\n<p>string</p>");
+    });
 });


### PR DESCRIPTION
The helper replaces line breaks in plain text with appropriate HTML; a single newline becomes an HTML line break (<br />) and a new line followed by a blank line becomes a paragraph break (</p>).

Similar to the `linebreaks` filter in Django templates.

/cc @bartek 
